### PR TITLE
[FEATURE] Add initial docker development configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /htmldocs/
 /src/*.egg-info/
 __pycache__/
+.sample.env

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,17 @@ In the box labeled ``Access for Test (writers)``, enter the string ``*``.  That 
 
 You should now be able to select your new event from the ``Event`` menu at the top right, and then create new incidents within that event.
 
+Development with docker
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Build the Docker Image:
+
+    docker compose build app
+
+Run the App
+
+    docker compose up app -d
+
 Pull Requests
 ~~~~~~~~~~~~~
 

--- a/conf/imsd-sample-docker.conf
+++ b/conf/imsd-sample-docker.conf
@@ -1,0 +1,56 @@
+[Core]
+
+# Absolute or relative to parent of parent of this file
+ServerRoot = .
+
+DataStore = SQLite
+Directory = File
+
+# Absolute or relative to ServerRoot
+ConfigRoot      = conf
+DataRoot        = data
+CachedResources = cache
+
+# Bind address
+Host = 0.0.0.0
+Port = 8080
+
+Admins = Hardware, Loosy
+
+#MasterKey = 6C21E8C9-8B83-4EA3-93BD-6C6EFE8A712B
+
+#JWTSecret = DD264110-3A97-4348-9473-6D50B582550C
+
+RequireActive = True
+
+
+[Store:SQLite]
+
+# Relative to DataRoot
+File = db.sqlite
+
+
+[Store:MySQL]
+
+HostName = localhost
+HostPort = 3306
+
+Database = ims
+UserName = ims
+Password = 7B33108D-4CD4-41B5-A244-B16F97038860
+
+
+[Directory:File]
+
+# Relative to ConfigRoot
+File = directory.yaml
+
+
+[Directory:ClubhouseDB]
+
+Hostname = dms.rangers.example.com
+HostPort = 3306
+
+Database = rangers
+Username = ims
+Password = 9F29BB2B-E775-489C-9C20-9FE3EFEE1F22

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,21 @@
+# -----------------------------------------------------------------------------
+# This stage builds the development container.
+# -----------------------------------------------------------------------------
+FROM python:3.12.1-alpine3.18 as development
+
+# Paths
+ARG IMS_SERVER_ROOT="/srv/ims"
+
+# Install libraries.
+RUN apk add --no-cache libressl
+RUN pip install --upgrade setuptools
+RUN pip install --upgrade tox
+RUN rm -rf /root/.cache
+
+# Allow Python to bind to privileged port numbers
+RUN apk add --no-cache libcap
+RUN setcap "cap_net_bind_service=+ep" /usr/local/bin/python3.12
+
+# Set user and default working directory
+USER daemon:daemon
+WORKDIR "${IMS_SERVER_ROOT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3.7'
 
 services:
-  ims_server: 
-    container_name: ims_server
+  app: 
+    container_name: ranger_ims_server
     user: :${DAEMON_GROUP_ID:-1420}
     build:
       dockerfile: ./dev.Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,4 @@ services:
     
 networks:
   default:
-    external: true
     name: "${DOCKER_RANGERS_NETWORK:-rangers}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,8 @@ services:
     ports:
      - ${IMS_SERVER_PORT:-8080}:8080
     command: "tox run -e exec"
+    
+networks:
+  default:
+    external: true
+    name: "${DOCKER_RANGERS_NETWORK:-rangers}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.7'
+
+services:
+  ims_server: 
+    container_name: ims_server
+    user: :${DAEMON_GROUP_ID:-1420}
+    build:
+      dockerfile: ./dev.Dockerfile
+    volumes:
+     - ./:/srv/ims
+    ports:
+     - ${IMS_SERVER_PORT:-8080}:8080
+    command: "tox run -e exec"

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,2 @@
+DAEMON_GROUP_ID=1420 # Match your docker group ID for permissions
+IMS_SERVER_PORT=8080


### PR DESCRIPTION
## Overview

Goal is to support faster development environment provisioning with a docker & docker-compose setup.

### WIP TODO

 - [ ] Organize docker files in `docker` directory
 - [ ] Add `caddy` reverse proxy with `ims.lvh.me` domain or similar
 - [ ] Fix up Dockerfile for direct `docker run` for non-compose use
 - [x] Add `README` steps for development
 - [ ] Add ability to run linters & tests from compose commands